### PR TITLE
Sheng/client side prediction

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,10 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "colyseus.js": "^0.14.13",
+        "matter-js": "^0.19.0",
         "phaser": "^3.60.0",
         "phaser3-rex-plugins": "^1.60.1"
       },
       "devDependencies": {
+        "@types/matter-js": "^0.18.5",
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.5",
         "webpack": "^5.75.0",
@@ -136,6 +138,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/matter-js": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@types/matter-js/-/matter-js-0.18.5.tgz",
+      "integrity": "sha512-CV8m/FUmjmFNFcI7fUnsKcCLeqbf0kzWdKOTLGrpfKwWwrF6ggLaQlHNsg8267TkkiUAPoXY/7q6H9qwmR5TZg==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -979,6 +987,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/matter-js": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/matter-js/-/matter-js-0.19.0.tgz",
+      "integrity": "sha512-v2huwvQGOHTGOkMqtHd2hercCG3f6QAObTisPPHg8TZqq2lz7eIY/5i/5YUV8Ibf3mEioFEmwibcPUF2/fnKKQ=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,10 +13,12 @@
   "license": "ISC",
   "dependencies": {
     "colyseus.js": "^0.14.13",
+    "matter-js": "^0.19.0",
     "phaser": "^3.60.0",
     "phaser3-rex-plugins": "^1.60.1"
   },
   "devDependencies": {
+    "@types/matter-js": "^0.18.5",
     "ts-loader": "^9.4.2",
     "typescript": "^4.9.5",
     "webpack": "^5.75.0",

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -39,15 +39,15 @@ export default {
             mapping: 'rexUI'
         }]
     },
-    physics: {
-        default: 'matter',
-        matter: {
-            gravity: {
-                y: 0,
-            },
-            debug: true
-        }
-    },
+    // physics: {
+    //     default: 'matter',
+    //     matter: {
+    //         gravity: {
+    //             y: 0,
+    //         },
+    //         debug: true
+    //     }
+    // },
     dom: {
         createContainer: true
     },

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -39,15 +39,6 @@ export default {
             mapping: 'rexUI'
         }]
     },
-    // physics: {
-    //     default: 'matter',
-    //     matter: {
-    //         gravity: {
-    //             y: 0,
-    //         },
-    //         debug: true
-    //     }
-    // },
     dom: {
         createContainer: true
     },
@@ -86,7 +77,7 @@ export enum SceneKey {
 export type SceneKeyType = keyof typeof SceneKey;
 
 /** ------------ Change the scene key here to set the starting scene. ---------------*/
-export const StartScene = SceneKey.RoomScene;
+export const StartScene = SceneKey.MenuScene;
 
 const headerFontFamily = 'pressStart2P';
 const bodyFontFamily = 'aldrich';

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -86,7 +86,7 @@ export enum SceneKey {
 export type SceneKeyType = keyof typeof SceneKey;
 
 /** ------------ Change the scene key here to set the starting scene. ---------------*/
-export const StartScene = SceneKey.MenuScene;
+export const StartScene = SceneKey.RoomScene;
 
 const headerFontFamily = 'pressStart2P';
 const bodyFontFamily = 'aldrich';

--- a/client/src/gameobjs/Entity.ts
+++ b/client/src/gameobjs/Entity.ts
@@ -1,27 +1,52 @@
 import Phaser from "phaser";
+import GameObject from "./GameObject";
 
-export default abstract class Entity extends Phaser.Physics.Matter.Sprite
+export interface Stat {
+    hp?: number;
+    maxHp?: number;
+    mana?: number;
+    maxMana?: number;
+
+    armor?: number;
+    magicResist?: number;
+
+    damagePercent?: number;
+
+    attack?: number;
+    attackPercent?: number;
+    armorPen?: number;
+
+
+    magicAttack?: number;
+    magicAttackPercent?: number;
+    magicPen?: number;
+
+    critRate?: number;
+    critDamage?: number;
+
+    attackRange?: number;
+    attackRangePercent?: number;
+
+    attackSpeed?: number;
+    attackSpeedPercent?: number;
+
+    speed?: number;
+
+    lifeSteal?: number;
+
+    level?: number;
+}
+
+export default abstract class Entity extends GameObject
 {
-    serverX: number;
-    serverY: number;
+    private stat: Stat;
 
     constructor(scene: Phaser.Scene, x: number, y: number, texture: string|Phaser.Textures.Texture) {
-        super(scene.matter.world, x, y, texture);
-        this.setSensor(true);
-        this.serverX = x;
-        this.serverY = y;
+        super(scene, x, y, texture);
+        this.stat = {};
     }
 
-    // public initializeListeners(entityState:any) {
-    //     entityState.onChange = (changes:any) => {
-    //         // changes.forEach(({field, value}: any) => {
-    //         //     switch(field) {
-    //         //         case "x": this.x = value; break;
-    //         //         case "y": this.y = value; break;
-    //         //     }
-    //         // })
-    //         this.serverX = entityState.x;
-    //         this.serverY = entityState.y;
-    //     }
-    // }
+    public getStat() {
+        return this.stat;
+    }
 }

--- a/client/src/gameobjs/Entity.ts
+++ b/client/src/gameobjs/Entity.ts
@@ -49,4 +49,11 @@ export default abstract class Entity extends GameObject
     public getStat() {
         return this.stat;
     }
+
+    /** Updates the stat by copying provided values to the stat.
+     *  @param stat new Stat values.
+     */
+    public updateStat(stat: Stat) {
+        Object.assign(this.stat, stat);
+    }
 }

--- a/client/src/gameobjs/Entity.ts
+++ b/client/src/gameobjs/Entity.ts
@@ -2,30 +2,26 @@ import Phaser from "phaser";
 
 export default abstract class Entity extends Phaser.Physics.Matter.Sprite
 {
+    serverX: number;
+    serverY: number;
 
-    constructor(scene: Phaser.Scene) {
-        super(scene.matter.world, 0, 0, "");
+    constructor(scene: Phaser.Scene, x: number, y: number, texture: string|Phaser.Textures.Texture) {
+        super(scene.matter.world, x, y, texture);
+        this.setSensor(true);
+        this.serverX = x;
+        this.serverY = y;
     }
 
-    public initializeListeners(entityState:any) {
-        entityState.onChange = (changes:any) => {
-            changes.forEach(({field, value}: any) => {
-                switch(field) {
-                    case "x": this.x = value; break;
-                    case "y": this.y = value; break;
-                    // case "velocity": {
-                    //     this.setVelocity(value.x, value.y);
-                    // }; break;
-                }
-            })
-        }
-        // entityState.velocity.onChange = (changes: any) => {
-        //     changes.forEach(({field, value}: any) => {
-        //         switch(field) {
-        //             case "x": this.setVelocityX(value); break;
-        //             case "y": this.setVelocityY(value); break;
-        //         }
-        //     })
-        // }
-    }
+    // public initializeListeners(entityState:any) {
+    //     entityState.onChange = (changes:any) => {
+    //         // changes.forEach(({field, value}: any) => {
+    //         //     switch(field) {
+    //         //         case "x": this.x = value; break;
+    //         //         case "y": this.y = value; break;
+    //         //     }
+    //         // })
+    //         this.serverX = entityState.x;
+    //         this.serverY = entityState.y;
+    //     }
+    // }
 }

--- a/client/src/gameobjs/GameObject.ts
+++ b/client/src/gameobjs/GameObject.ts
@@ -1,0 +1,14 @@
+
+
+export default abstract class GameObject extends Phaser.Physics.Matter.Sprite
+{
+    serverX: number;
+    serverY: number;
+
+    constructor(scene: Phaser.Scene, x: number, y: number, texture: string|Phaser.Textures.Texture) {
+        super(scene.matter.world, x, y, texture);
+        this.setSensor(true);
+        this.serverX = x;
+        this.serverY = y;
+    }
+}

--- a/client/src/gameobjs/GameObject.ts
+++ b/client/src/gameobjs/GameObject.ts
@@ -1,14 +1,18 @@
 
 
-export default abstract class GameObject extends Phaser.Physics.Matter.Sprite
+export default abstract class GameObject extends Phaser.GameObjects.Sprite
 {
     serverX: number;
     serverY: number;
+    serverState: any;
 
     constructor(scene: Phaser.Scene, x: number, y: number, texture: string|Phaser.Textures.Texture) {
-        super(scene.matter.world, x, y, texture);
-        this.setSensor(true);
+        super(scene, x, y, texture);
         this.serverX = x;
         this.serverY = y;
+    }
+
+    public setServerState(serverState: any) {
+        this.serverState = serverState;
     }
 }

--- a/client/src/gameobjs/Monster.ts
+++ b/client/src/gameobjs/Monster.ts
@@ -3,17 +3,10 @@ import Entity from "./Entity";
 export default class Monster extends Entity
 {
     private monsterState: any;
-    private speed: number;
 
     constructor(scene:Phaser.Scene, monsterState:any) {
-        super(scene);
+        super(scene, monsterState.x, monsterState.y, monsterState.monsterName);
         this.monsterState = monsterState;
-        this.initializeListeners(this.monsterState);
-        console.log(`Monster Name: ${monsterState.monsterName}`);
-        this.setTexture(monsterState.monsterName);
-        this.x = monsterState.x;
-        this.y = monsterState.y;
-        this.speed = monsterState.stat.speed;
     }
 
     // /**Add listeners to connect to the server's player*/

--- a/client/src/gameobjs/Player.ts
+++ b/client/src/gameobjs/Player.ts
@@ -4,8 +4,7 @@ export default class Player extends Entity
     private playerState: any;
 
     constructor(scene:Phaser.Scene,playerState:any) {
-        super(scene);
-        this.setTexture("demo_hero");
+        super(scene, playerState.x, playerState.y, "demo_hero");
         this.playerState = playerState;
     }
 

--- a/client/src/gameobjs/Player.ts
+++ b/client/src/gameobjs/Player.ts
@@ -20,4 +20,8 @@ export default class Player extends Entity
     //     }
     // }
 
+    public getPlayerState() {
+        return this.playerState;
+    }
+
 }

--- a/client/src/gameobjs/Projectile.ts
+++ b/client/src/gameobjs/Projectile.ts
@@ -1,6 +1,7 @@
 import Entity from "./Entity";
+import GameObject from "./GameObject";
 
-export default class Projectile extends Entity
+export default class Projectile extends GameObject
 {
     private projectileState: any;
 

--- a/client/src/gameobjs/Projectile.ts
+++ b/client/src/gameobjs/Projectile.ts
@@ -1,4 +1,3 @@
-import Entity from "./Entity";
 import GameObject from "./GameObject";
 
 export default class Projectile extends GameObject

--- a/client/src/gameobjs/Projectile.ts
+++ b/client/src/gameobjs/Projectile.ts
@@ -1,0 +1,12 @@
+import Entity from "./Entity";
+
+export default class Projectile extends Entity
+{
+    private projectileState: any;
+
+    constructor(scene:Phaser.Scene,projectileState:any) {
+        super(scene, projectileState.x, projectileState.y, projectileState.sprite);
+        this.projectileState = projectileState;
+    }
+
+}

--- a/client/src/gameobjs/Tile.ts
+++ b/client/src/gameobjs/Tile.ts
@@ -1,0 +1,12 @@
+import GameObject from "./GameObject";
+
+export default class Tile extends GameObject
+{
+
+    constructor(scene:Phaser.Scene, tileState: any) {
+        super(scene, tileState.x, tileState.y, "");
+        this.width = 16;
+        this.height = 16;
+    }
+
+}

--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -12,12 +12,6 @@ export default class GameScene extends Phaser.Scene {
     private gameRoom?: Colyseus.Room;
     private gameManager?: GameManager;
 
-    private upKey?: Phaser.Input.Keyboard.Key;
-    private downKey?: Phaser.Input.Keyboard.Key;
-    private leftKey?: Phaser.Input.Keyboard.Key;
-    private rightKey?: Phaser.Input.Keyboard.Key;
-    private spaceKey?: Phaser.Input.Keyboard.Key;
-    private debugKey?: Phaser.Input.Keyboard.Key;
 
     constructor() {
         super(SceneKey.GameScene);
@@ -32,13 +26,11 @@ export default class GameScene extends Phaser.Scene {
     create() {
         //Initialize fields
         this.initializeUI();
-        this.initializeInputs();
         this.joinGameRoom();
     }
 
-    update(deltaT: number) {
-        this.sendServerInputMessage();
-        this.gameManager?.update(deltaT);
+    update(time: number, deltaT: number) {
+        this.gameManager?.update(time, deltaT);
     }
 
     /** Runs when the player successfully joined the game room */
@@ -52,42 +44,6 @@ export default class GameScene extends Phaser.Scene {
 
     private initializeUI() {
         this.cameras.main.setZoom(1.5);
-    }
-
-    private initializeInputs() {
-        this.upKey = this.input.keyboard.addKey("W");
-        this.downKey = this.input.keyboard.addKey("S");
-        this.rightKey = this.input.keyboard.addKey("D");
-        this.leftKey = this.input.keyboard.addKey("A");
-        this.spaceKey = this.input.keyboard.addKey("SPACE");
-
-        // Debug controls, not visible by default. Can be disabled in config.ts.
-        this.debugKey = this.input.keyboard.addKey("F3");
-        this.debugKey.on("down", () => {
-            this.matter.world.debugGraphic?.setVisible(!this.matter.world.debugGraphic.visible);
-        })
-        this.matter.world.debugGraphic?.setVisible(false);
-    }
-
-    private sendServerInputMessage() {
-        //[0] up, [1] down, [2] left, [3] right, 
-        let movementData = [0, 0, 0, 0]
-        movementData[0] = this.upKey?.isDown? 1 : 0;
-        movementData[1] = this.downKey?.isDown? 1 : 0;
-        movementData[2] = this.leftKey?.isDown? 1 : 0;
-        movementData[3] = this.rightKey?.isDown? 1 : 0;
-        this.gameRoom?.send("move", movementData)
-
-        let special = this.spaceKey?.isDown? true : false;
-        this.gameRoom?.send("special", special);
-        
-
-        //[0] mouse click, [1] mousex, [2] mousey.
-        let mouseData = [0, 0, 0]
-        mouseData[0] = this.input.mousePointer.isDown? 1 : 0;
-        mouseData[1] = this.input.mousePointer.worldX;
-        mouseData[2] = this.input.mousePointer.worldY;
-        this.gameRoom?.send("attack", mouseData);
     }
 
     private joinGameRoom() {

--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -46,42 +46,42 @@ export default class GameScene extends Phaser.Scene {
         this.cameras.main.setZoom(1.5);
     }
 
-    private initializeInputs() {
-        this.upKey = this.input.keyboard?.addKey("W");
-        this.downKey = this.input.keyboard?.addKey("S");
-        this.rightKey = this.input.keyboard?.addKey("D");
-        this.leftKey = this.input.keyboard?.addKey("A");
-        this.spaceKey = this.input.keyboard?.addKey("SPACE");
+    // private initializeInputs() {
+    //     this.upKey = this.input.keyboard?.addKey("W");
+    //     this.downKey = this.input.keyboard?.addKey("S");
+    //     this.rightKey = this.input.keyboard?.addKey("D");
+    //     this.leftKey = this.input.keyboard?.addKey("A");
+    //     this.spaceKey = this.input.keyboard?.addKey("SPACE");
 
-        // Debug controls, not visible by default. Can be disabled in config.ts.
-        this.debugKey = this.input.keyboard?.addKey("F3");
-        this.debugKey?.on("down", () => {
-            this.matter.world.debugGraphic?.setVisible(!this.matter.world.debugGraphic.visible);
-        })
-        this.matter.world.debugGraphic?.setVisible(false);
-    }
+    //     // Debug controls, not visible by default. Can be disabled in config.ts.
+    //     this.debugKey = this.input.keyboard?.addKey("F3");
+    //     this.debugKey?.on("down", () => {
+    //         this.matter.world.debugGraphic?.setVisible(!this.matter.world.debugGraphic.visible);
+    //     })
+    //     this.matter.world.debugGraphic?.setVisible(false);
+    // }
 
-    private sendServerInputMessage() {
-        //[0] up, [1] down, [2] left, [3] right, 
-        let movementData = [0, 0, 0, 0]
-        movementData[0] = this.upKey?.isDown? 1 : 0;
-        movementData[1] = this.downKey?.isDown? 1 : 0;
-        movementData[2] = this.leftKey?.isDown? 1 : 0;
-        movementData[3] = this.rightKey?.isDown? 1 : 0;
-        this.gameRoom?.send("move", movementData)
+    // private sendServerInputMessage() {
+    //     //[0] up, [1] down, [2] left, [3] right, 
+    //     let movementData = [0, 0, 0, 0]
+    //     movementData[0] = this.upKey?.isDown? 1 : 0;
+    //     movementData[1] = this.downKey?.isDown? 1 : 0;
+    //     movementData[2] = this.leftKey?.isDown? 1 : 0;
+    //     movementData[3] = this.rightKey?.isDown? 1 : 0;
+    //     this.gameRoom?.send("move", movementData)
 
-        let special = this.spaceKey?.isDown? true : false;
-        this.gameRoom?.send("special", special);
+    //     let special = this.spaceKey?.isDown? true : false;
+    //     this.gameRoom?.send("special", special);
         
 
-        //[0] mouse click, [1] mousex, [2] mousey.
-        let mouseData = [0, 0, 0]
-        mouseData[0] = this.input.mousePointer.isDown? 1 : 0;
-        this.input.mousePointer.updateWorldPoint(this.cameras.main);
-        mouseData[1] = this.input.mousePointer.worldX;
-        mouseData[2] = this.input.mousePointer.worldY;
-        this.gameRoom?.send("attack", mouseData);
-    }
+    //     //[0] mouse click, [1] mousex, [2] mousey.
+    //     let mouseData = [0, 0, 0]
+    //     mouseData[0] = this.input.mousePointer.isDown? 1 : 0;
+    //     this.input.mousePointer.updateWorldPoint(this.cameras.main);
+    //     mouseData[1] = this.input.mousePointer.worldX;
+    //     mouseData[2] = this.input.mousePointer.worldY;
+    //     this.gameRoom?.send("attack", mouseData);
+    // }
 
     private joinGameRoom() {
         ClientManager.getClient().joinGameRoom().then((room) => {

--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -36,8 +36,9 @@ export default class GameScene extends Phaser.Scene {
         this.joinGameRoom();
     }
 
-    update() {
+    update(deltaT: number) {
         this.sendServerInputMessage();
+        this.gameManager?.update(deltaT);
     }
 
     /** Runs when the player successfully joined the game room */

--- a/client/src/system/ClientSidePrediction.ts
+++ b/client/src/system/ClientSidePrediction.ts
@@ -7,9 +7,10 @@ interface PlayerInput {
 
 }
 
-interface GameObjectAndBodyPair {
+interface GameObjectItem {
     gameObject: GameObject;
     body: Matter.Body;
+    debugGraphic: Phaser.GameObjects.Graphics;
 }
 
 /**
@@ -29,12 +30,34 @@ export default class ClientSidePrediction {
     private history: Matter.World[] = [];
     private historyStartTick: number = 0;
     private engine: Matter.Engine;
-    private gameObjectPairs: GameObjectAndBodyPair[] = [];
+    private scene: Phaser.Scene;
+    private gameObjectItems: GameObjectItem[] = [];
 
     private serverTickCount: number = 0;
     private clientTickCount: number = 0;
 
-    constructor() {
+    private debugGraphicsVisible: boolean = false;
+
+    private matterBodyConfig = {
+        Player: {
+            isStatic: false,
+            isSensor: false,
+            inertia: Infinity,
+            inverseInertia: 0,
+            restitution: 0,
+            friction: 0,
+        },
+        Tile: {
+            isStatic: true,
+            isSensor: false,
+            inverseInertia: 0,
+            restitution: 0,
+            friction: 0,
+        }
+    }
+
+    constructor(scene: Phaser.Scene) {
+        this.scene = scene;
         this.engine = Matter.Engine.create();
         this.engine.gravity.y = 0;
         // let worldClone = Matter.Common.clone(this.engine.world, true);
@@ -51,8 +74,8 @@ export default class ClientSidePrediction {
 
     public getPlayer1AndBody() {
         if(this.player1Body === undefined) {
-            this.gameObjectPairs.forEach((pair) => {
-                if(pair.gameObject === this.player1) this.player1Body = pair.body;
+            this.gameObjectItems.forEach((item) => {
+                if(item.gameObject === this.player1) this.player1Body = item.body;
             })
         }
         return {player1: this.player1, body: this.player1Body};
@@ -61,9 +84,8 @@ export default class ClientSidePrediction {
     public update(deltaT: number, playerMovementData: number[]) {
         this.processPlayerMovement(playerMovementData);
         Matter.Engine.update(this.engine, deltaT);
+        if(this.debugGraphicsVisible) this.updateDebugGraphics();
         this.clientTickCount++;
-
-        console.log(this.clientTickCount - this.serverTickCount);
     }
 
     private initializeEvents() {
@@ -75,8 +97,20 @@ export default class ClientSidePrediction {
                 player1.serverY = body.position.y;
             }
         });
+
+        Matter.Events.on(this.engine, "collisionStart", () => {
+            console.log("collision");
+        })
     }
 
+    private updateDebugGraphics() {
+        this.gameObjectItems.forEach((item) => {
+            let graphics = item.debugGraphic;
+            let gameObj = item.gameObject;
+            graphics.setX(gameObj.serverX);
+            graphics.setY(gameObj.serverY);
+        })
+    }
     
     private processPlayerMovement(data: number[]) {
         let {player1, body} = this.getPlayer1AndBody();
@@ -92,24 +126,47 @@ export default class ClientSidePrediction {
         if(body) Matter.Body.setVelocity(body, velocity);
     }
 
+    public setDebugGraphicsVisible(value: boolean) {
+        if(value === true) {
+            this.updateDebugGraphics();
+            this.gameObjectItems.forEach(item => item.debugGraphic.setVisible(true));
+        }
+        else this.gameObjectItems.forEach(item => item.debugGraphic.setVisible(false));
+        this.debugGraphicsVisible = value;
+    }
+
+    public getDebugGraphicsVisible() {
+        return this.debugGraphicsVisible;
+    }
+
     public processTick() {
 
     }
 
     public addGameObject(gameObject: GameObject) {
-        let gameObjectAndBodyPair = {
-            gameObject: gameObject,
-            body: Matter.Bodies.rectangle(gameObject.serverX, gameObject.serverY, gameObject.width, gameObject.height, {
-                isStatic: false,
-                isSensor: true,
-                inverseInertia: 0,
-                restitution: 0,
-                friction: 0,
-            })
-        }
 
-        this.gameObjectPairs.push(gameObjectAndBodyPair);
-        Matter.Composite.add(this.engine.world, gameObjectAndBodyPair.body);
+        let matterConfig = {
+            isStatic: false,
+            isSensor: true,
+            inverseInertia: 0,
+            restitution: 0,
+            friction: 0,
+        };
+
+        if(gameObject.serverState.type === "Tile") matterConfig = this.matterBodyConfig["Tile"];
+        if(gameObject.serverState.type === "Player") matterConfig = this.matterBodyConfig["Player"];
+
+        let gameObjectItem = {
+            gameObject: gameObject,
+            body: Matter.Bodies.rectangle(gameObject.serverX, gameObject.serverY, gameObject.width, gameObject.height, matterConfig),
+            debugGraphic: this.scene.add.graphics({lineStyle: {width: 1, color: 0x0000cc}})
+                .strokeRect(-gameObject.width / 2,-gameObject.height / 2, gameObject.width, gameObject.height)
+                .setVisible(this.debugGraphicsVisible)
+                .setDepth(10),
+        }            
+
+        this.gameObjectItems.push(gameObjectItem);
+        Matter.Composite.add(this.engine.world, gameObjectItem.body);
     }
 
     public serverReconciliation() {

--- a/client/src/system/ClientSidePrediction.ts
+++ b/client/src/system/ClientSidePrediction.ts
@@ -1,0 +1,13 @@
+
+/**
+ * The ClientSidePrediction class will manage the prediction of player1 to match that of the server's.
+ * Its main purpose would be movement prediction. Which would consist of the following:
+ *  - Movement from WASD
+ *  - Movement blocked by obstacles
+ *  - Animations from movement
+ * 
+ * To accomplish this updates on both the client and server would need to be deterministic.
+ */
+export default class ClientSidePrediction {
+
+}

--- a/client/src/system/ClientSidePrediction.ts
+++ b/client/src/system/ClientSidePrediction.ts
@@ -28,13 +28,14 @@ export default class ClientSidePrediction {
     private player1State?: any;
     private player1Body?: Matter.Body;
     private history: Matter.World[] = [];
+    private inputHistory: number[] = [];
     private historyStartTick: number = 0;
     private engine: Matter.Engine;
     private scene: Phaser.Scene;
     private gameObjectItems: GameObjectItem[] = [];
 
     private serverTickCount: number = 0;
-    private clientTickCount: number = 0;
+    private clientTickCount: number = 8;
 
     private debugGraphicsVisible: boolean = false;
 
@@ -98,9 +99,9 @@ export default class ClientSidePrediction {
             }
         });
 
-        Matter.Events.on(this.engine, "collisionStart", () => {
-            console.log("collision");
-        })
+        // Matter.Events.on(this.engine, "collisionStart", () => {
+        //     //console.log("collision");
+        // })
     }
 
     private updateDebugGraphics() {
@@ -141,6 +142,10 @@ export default class ClientSidePrediction {
 
     public processTick() {
 
+    }
+
+    public getClientTickCount() {
+        return this.clientTickCount;
     }
 
     public addGameObject(gameObject: GameObject) {

--- a/client/src/system/ClientSidePrediction.ts
+++ b/client/src/system/ClientSidePrediction.ts
@@ -31,6 +31,9 @@ export default class ClientSidePrediction {
     private engine: Matter.Engine;
     private gameObjectPairs: GameObjectAndBodyPair[] = [];
 
+    private serverTickCount: number = 0;
+    private clientTickCount: number = 0;
+
     constructor() {
         this.engine = Matter.Engine.create();
         this.engine.gravity.y = 0;
@@ -42,7 +45,7 @@ export default class ClientSidePrediction {
         this.player1 = player1;
         this.player1State = player1State;
         serverState.onChange = (changes: any) => {
-            console.log(serverState.serverTickCount);
+            this.serverTickCount = serverState.serverTickCount;
         }
     }
 
@@ -58,6 +61,9 @@ export default class ClientSidePrediction {
     public update(deltaT: number, playerMovementData: number[]) {
         this.processPlayerMovement(playerMovementData);
         Matter.Engine.update(this.engine, deltaT);
+        this.clientTickCount++;
+
+        console.log(this.clientTickCount - this.serverTickCount);
     }
 
     private initializeEvents() {

--- a/client/src/system/ClientSidePrediction.ts
+++ b/client/src/system/ClientSidePrediction.ts
@@ -1,8 +1,15 @@
-import MatterJS from "matter";
+import Matter, { Common } from "matter-js";
 import Player from "../gameobjs/Player";
+import MathUtil from "../util/MathUtil";
+import GameObject from "../gameobjs/GameObject";
 
 interface PlayerInput {
 
+}
+
+interface GameObjectAndBodyPair {
+    gameObject: GameObject;
+    body: Matter.Body;
 }
 
 /**
@@ -16,34 +23,87 @@ interface PlayerInput {
  */
 export default class ClientSidePrediction {
     
-    private player1: Player;
-    private history: MatterJS.World[] = [];
+    private player1?: Player;
+    private player1State?: any;
+    private player1Body?: Matter.Body;
+    private history: Matter.World[] = [];
     private historyStartTick: number = 0;
+    private engine: Matter.Engine;
+    private gameObjectPairs: GameObjectAndBodyPair[] = [];
 
-    constructor(player1: Player) {
-        MatterJS.Engine
-        this.player1 = player1;
+    constructor() {
+        this.engine = Matter.Engine.create();
+        this.engine.gravity.y = 0;
+        // let worldClone = Matter.Common.clone(this.engine.world, true);
+        this.initializeEvents();
     }
 
-    public update(playerMovementData: number[]) {
-        // let {playerBody, playerState} = this.getPlayerStateAndBody(playerId)
-        
-        // if(!playerBody || !playerState) return console.log("player does not exist")
+    public addPlayer1(player1: Player, player1State: any, serverState: any) {
+        this.player1 = player1;
+        this.player1State = player1State;
+        serverState.onChange = (changes: any) => {
+            console.log(serverState.serverTickCount);
+        }
+    }
 
-        // //calculate new player velocity
-        // let speed = this.player1.getVelocity();
-        // let x = 0;
-        // let y = 0;
-        // if(playerMovementData[0]) y -= 1;
-        // if(playerMovementData[1]) y += 1;
-        // if(playerMovementData[2]) x -= 1;
-        // if(playerMovementData[3]) x += 1;
-        // let velocity = MathUtil.getNormalizedSpeed(x, y, speed)
-        // Matter.Body.setVelocity(playerBody, velocity);
+    public getPlayer1AndBody() {
+        if(this.player1Body === undefined) {
+            this.gameObjectPairs.forEach((pair) => {
+                if(pair.gameObject === this.player1) this.player1Body = pair.body;
+            })
+        }
+        return {player1: this.player1, body: this.player1Body};
+    }
+
+    public update(deltaT: number, playerMovementData: number[]) {
+        this.processPlayerMovement(playerMovementData);
+        Matter.Engine.update(this.engine, deltaT);
+    }
+
+    private initializeEvents() {
+        // sync player position
+        Matter.Events.on(this.engine, "afterUpdate", () => {
+            let {player1, body} = this.getPlayer1AndBody();
+            if(player1 && body) {
+                player1.serverX = body.position.x;
+                player1.serverY = body.position.y;
+            }
+        });
+    }
+
+    
+    private processPlayerMovement(data: number[]) {
+        let {player1, body} = this.getPlayer1AndBody();
+        //calculate new player velocity
+        let speed = player1?.getStat().speed;
+        let x = 0;
+        let y = 0;
+        if(data[0]) y -= 1;
+        if(data[1]) y += 1;
+        if(data[2]) x -= 1;
+        if(data[3]) x += 1;
+        let velocity = MathUtil.getNormalizedSpeed(x, y, speed ?? 0);
+        if(body) Matter.Body.setVelocity(body, velocity);
     }
 
     public processTick() {
 
+    }
+
+    public addGameObject(gameObject: GameObject) {
+        let gameObjectAndBodyPair = {
+            gameObject: gameObject,
+            body: Matter.Bodies.rectangle(gameObject.serverX, gameObject.serverY, gameObject.width, gameObject.height, {
+                isStatic: false,
+                isSensor: true,
+                inverseInertia: 0,
+                restitution: 0,
+                friction: 0,
+            })
+        }
+
+        this.gameObjectPairs.push(gameObjectAndBodyPair);
+        Matter.Composite.add(this.engine.world, gameObjectAndBodyPair.body);
     }
 
     public serverReconciliation() {

--- a/client/src/system/ClientSidePrediction.ts
+++ b/client/src/system/ClientSidePrediction.ts
@@ -1,3 +1,9 @@
+import MatterJS from "matter";
+import Player from "../gameobjs/Player";
+
+interface PlayerInput {
+
+}
 
 /**
  * The ClientSidePrediction class will manage the prediction of player1 to match that of the server's.
@@ -9,5 +15,38 @@
  * To accomplish this updates on both the client and server would need to be deterministic.
  */
 export default class ClientSidePrediction {
+    
+    private player1: Player;
+    private history: MatterJS.World[] = [];
+    private historyStartTick: number = 0;
 
+    constructor(player1: Player) {
+        MatterJS.Engine
+        this.player1 = player1;
+    }
+
+    public update(playerMovementData: number[]) {
+        // let {playerBody, playerState} = this.getPlayerStateAndBody(playerId)
+        
+        // if(!playerBody || !playerState) return console.log("player does not exist")
+
+        // //calculate new player velocity
+        // let speed = this.player1.getVelocity();
+        // let x = 0;
+        // let y = 0;
+        // if(playerMovementData[0]) y -= 1;
+        // if(playerMovementData[1]) y += 1;
+        // if(playerMovementData[2]) x -= 1;
+        // if(playerMovementData[3]) x += 1;
+        // let velocity = MathUtil.getNormalizedSpeed(x, y, speed)
+        // Matter.Body.setVelocity(playerBody, velocity);
+    }
+
+    public processTick() {
+
+    }
+
+    public serverReconciliation() {
+
+    }
 }

--- a/client/src/system/GameManager.ts
+++ b/client/src/system/GameManager.ts
@@ -60,15 +60,17 @@ export default class GameManager {
     }
 
     private initializeInputs() {
-        this.upKey = this.scene.input.keyboard.addKey("W");
-        this.downKey = this.scene.input.keyboard.addKey("S");
-        this.rightKey = this.scene.input.keyboard.addKey("D");
-        this.leftKey = this.scene.input.keyboard.addKey("A");
-        this.spaceKey = this.scene.input.keyboard.addKey("SPACE");
+        this.upKey = this.scene.input.keyboard?.addKey("W");
+        this.downKey = this.scene.input.keyboard?.addKey("S");
+        this.rightKey = this.scene.input.keyboard?.addKey("D");
+        this.leftKey = this.scene.input.keyboard?.addKey("A");
+        this.spaceKey = this.scene.input.keyboard?.addKey("SPACE");
+
+        //console.log("Keyboard---------------", this.scene.input.keyboard);
 
         // Debug controls, not visible by default. Can be disabled in config.ts.
-        this.debugKey = this.scene.input.keyboard.addKey("F3");
-        this.debugKey.on("down", () => {
+        this.debugKey = this.scene.input.keyboard?.addKey("F3");
+        this.debugKey?.on("down", () => {
             this.scene.matter.world.debugGraphic?.setVisible(!this.scene.matter.world.debugGraphic.visible);
         })
         this.scene.matter.world.debugGraphic?.setVisible(false);

--- a/client/src/system/GameManager.ts
+++ b/client/src/system/GameManager.ts
@@ -25,7 +25,7 @@ export default class GameManager {
     private debugKey?: Phaser.Input.Keyboard.Key;
 
     // ------- fixed tick --------
-    private timePerTick = 1000 / 60; // 60 ticks per second.
+    private timePerTick = 50; // 20 ticks per second.
     private timeTillNextTick: number;
 
     private csp!: ClientSidePrediction;
@@ -50,16 +50,19 @@ export default class GameManager {
             this.timeTillNextTick += this.timePerTick;
             this.fixedTick(time, this.timePerTick);
         }
-    }
-
-    private fixedTick(time: number, deltaT: number) {
         // perform linear interpolation.
         this.gameObjects?.forEach((obj) => {
-            //if(obj !== this.player1) {
-                obj.setX(Phaser.Math.Linear(obj.x, obj.serverX, 0.20));
-                obj.setY(Phaser.Math.Linear(obj.y, obj.serverY, 0.20));
-            //}
+            obj.setX(Phaser.Math.Linear(obj.x, obj.serverX, .10));
+            obj.setY(Phaser.Math.Linear(obj.y, obj.serverY, .10));
         })
+    }
+
+    /**
+     * Runs at a frame rate equivalent to the server's frame rate.
+     * @param time The current time in ms.
+     * @param deltaT The time that passed in ms.
+     */
+    private fixedTick(time: number, deltaT: number) {
         this.scene.input.mousePointer.updateWorldPoint(this.scene.cameras.main);
         let movementData = this.getPlayerMovementData();
         this.csp.update(deltaT, movementData);

--- a/client/src/system/GameManager.ts
+++ b/client/src/system/GameManager.ts
@@ -51,7 +51,23 @@ export default class GameManager {
             this.timeTillNextTick += this.timePerTick;
             this.fixedTick(time, this.timePerTick);
         }
-        // perform linear interpolation.
+        this.interpolateGameObjects();
+    }
+
+    /**
+     * Updates the gameObject's position to match the server's gameObject position.
+     */
+    public syncGameObjectsWithServer() {
+        this.gameObjects?.forEach((obj) => {
+            obj.setX(obj.serverX);
+            obj.setY(obj.serverY);
+        })
+    }
+
+    /**
+     * Updates the gameObject's position to be closer to the server's gameObject position.
+     */
+    private interpolateGameObjects() {
         this.gameObjects?.forEach((obj) => {
             obj.setX(Phaser.Math.Linear(obj.x, obj.serverX, .10));
             obj.setY(Phaser.Math.Linear(obj.y, obj.serverY, .10));
@@ -83,7 +99,7 @@ export default class GameManager {
         // Debug controls, not visible by default. Can be disabled in config.ts.
         this.debugKey = this.scene.input.keyboard?.addKey("F3");
         this.debugKey?.on("down", () => {
-            this.csp.setDebugGraphicsVisible(!this.csp.getDebugGraphicsVisible());
+            this.csp.setDebugGraphicsVisible(!this.csp.isDebugGraphicsVisible());
         })
     }
 
@@ -125,29 +141,6 @@ export default class GameManager {
         movementData[4] = this.csp.getClientTickCount();
         return movementData;
     }
-
-    // private updatePlayer1(movementData: number[], special: boolean, mouseData: number[]) {
-    //     if(this.player1 !== undefined) {
-    //         let playerState = this.player1?.getPlayerState();
-
-    //         //calculate new player velocity
-    //         let speed = playerState.stat.speed;
-    //         let x = 0;
-    //         let y = 0;
-    //         if(movementData[0]) y -= 1;
-    //         if(movementData[1]) y += 1;
-    //         if(movementData[2]) x -= 1;
-    //         if(movementData[3]) x += 1;
-    //         let velocity = MathUtil.getNormalizedSpeed(x, y, speed)
-    //         this.player1.setVelocity(velocity.x, velocity.y);
-    //     }
-    // }
-    
-    // private getTypeOfObject(gameObj: any): string{
-    //     if(gameObj.hasOwnProperty('role')) return "player";
-    //     if(gameObj.hasOwnProperty('ownerId')) return "projectile"
-    //     else return ""
-    // }
 
     private onAdd = (gameObj:any, key:string) => {
         if(!gameObj) return;

--- a/client/src/system/GameManager.ts
+++ b/client/src/system/GameManager.ts
@@ -67,6 +67,7 @@ export default class GameManager {
         this.scene.input.mousePointer.updateWorldPoint(this.scene.cameras.main);
         let movementData = this.getPlayerMovementData();
         this.csp.update(deltaT, movementData);
+        movementData.push(this.csp.getAdjustmentId()); // Adds adjustmentId to payload.
         this.sendServerInputMessage(movementData);
     }
 
@@ -97,7 +98,7 @@ export default class GameManager {
 
     private sendServerInputMessage(movementData: number[]) {
         
-        this.gameRoom?.send("move", movementData)
+        this.gameRoom?.send("move", movementData);
 
         let special = this.spaceKey?.isDown? true : false;
         this.gameRoom?.send("special", special);
@@ -116,11 +117,12 @@ export default class GameManager {
 
     private getPlayerMovementData() {
         //[0] up, [1] down, [2] left, [3] right, 
-        let movementData = [0, 0, 0, 0]
+        let movementData = [0, 0, 0, 0, 0];
         movementData[0] = this.upKey?.isDown? 1 : 0;
         movementData[1] = this.downKey?.isDown? 1 : 0;
         movementData[2] = this.leftKey?.isDown? 1 : 0;
         movementData[3] = this.rightKey?.isDown? 1 : 0;
+        movementData[4] = this.csp.getClientTickCount();
         return movementData;
     }
 

--- a/client/src/util/MathUtil.ts
+++ b/client/src/util/MathUtil.ts
@@ -9,4 +9,17 @@ export default class MathUtil {
     public static generateRandomInteger(min:number, max:number) {
         return Math.floor(Math.random() * (max-min)) + min;
     }
+
+    /**
+     * 
+     * @param x x direction
+     * @param y y direction
+     * @param speed speed multiplier
+     * @returns normalized speed in direction <x,y>
+     */
+    public static getNormalizedSpeed(x: number, y: number, speed: number){
+        let mag = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
+        if(mag===0) return {x: 0, y: 0}
+        return {x: x/mag * speed, y: y/mag * speed}
+    }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,3 +16,5 @@ gameServer.define('game', GameRoom)
 gameServer.listen(PORT).then(() => {
     console.log("Game Server is listening on port: ", PORT);
 });
+
+gameServer.simulateLatency(33);

--- a/server/src/rooms/game_room/GameRoom.ts
+++ b/server/src/rooms/game_room/GameRoom.ts
@@ -1,11 +1,12 @@
 import { Client, Room, matchMaker } from "colyseus";
 import State from "./schemas/State";
 import GameManager from "./system/GameManager";
+import ReconciliationInfo from "./schemas/ReconciliationInfo";
 
 export default class GameRoom extends Room<State> {
     autoDispose = false;
     
-    private gameManager?: GameManager;
+    private gameManager!: GameManager;
 
     /** The time for our gameRoom to update once in milliseconds. 
      * Note: this is different from the server tick rate. 
@@ -38,27 +39,32 @@ export default class GameRoom extends Room<State> {
 
     initListeners() {
         this.onMessage("move", (client, msg)=>{
-            this.gameManager?.playerManager.processPlayerMovement(client.sessionId, msg)
+            //this.gameManager?.playerManager.processPlayerMovement(client.sessionId, msg)
+            this.gameManager.playerManager.queuePlayerMovement(client.sessionId, msg);
         })
 
         this.onMessage("attack", (client, msg)=>{
-            this.gameManager?.playerManager.processPlayerAttack(client.sessionId, msg)
+            this.gameManager.playerManager.processPlayerAttack(client.sessionId, msg)
         })
 
         this.onMessage("special", (client, msg)=>{
-            this.gameManager?.playerManager.processPlayerSpecial(client.sessionId, msg)
+            this.gameManager.playerManager.processPlayerSpecial(client.sessionId, msg)
         })
+
+        // this.onMessage("input", (client, msg) => {
+
+        // })
     }
 
     startGame() {
-        this.gameManager?.startGame();
+        this.gameManager.startGame();
         // Game Loop
         this.setSimulationInterval((deltaT) => {
             this.timeTillNextTick -= deltaT;
             while(this.timeTillNextTick <= 0) {
                 if(this.timeTillNextTick < -this.timePerTick * 5) {
                     console.warn(`Game Room: ${this.roomId} is more than 5 ticks behind, dropping ticks.`);
-                    this.timeTillNextTick = this.timePerTick;
+                    this.timeTillNextTick = 0;
                 }
                 this.timeTillNextTick += this.timePerTick;
                 this.fixedTick(this.timePerTick);
@@ -67,7 +73,7 @@ export default class GameRoom extends Room<State> {
     }
 
     fixedTick(deltaT: number) {
-        this.gameManager?.update(deltaT);
+        this.gameManager.update(deltaT);
         this.state.serverTickCount++;
         this.broadcastPatch(); //send patch updates to clients.
     }
@@ -78,12 +84,16 @@ export default class GameRoom extends Room<State> {
 
     onJoin(client: Client) {
         // Add a new player to the room state. The first player is the owner of the room.
-        this.gameManager?.playerManager.createPlayer(client.sessionId, this.gameManager?.playerCount() === 0);
+        this.gameManager.playerManager.createPlayer(client.sessionId, this.gameManager.playerCount() === 0);
+        this.state.reconciliationInfos.push(new ReconciliationInfo(client.sessionId));
     }
 
     onLeave(client: Client) {
         // removes player from list of gameobjects
-        this.gameManager?.removeGameObject(client.sessionId);
+        this.gameManager.playerManager.removePlayer(client.sessionId);
+        for(let i = this.state.reconciliationInfos.length - 1; i >= 0; i--) {
+            if(this.state.reconciliationInfos[i].clientId === client.sessionId) this.state.reconciliationInfos.deleteAt(i);
+        }
     }
 
     onDispose() {

--- a/server/src/rooms/game_room/GameRoom.ts
+++ b/server/src/rooms/game_room/GameRoom.ts
@@ -9,7 +9,7 @@ export default class GameRoom extends Room<State> {
     /** The time for our gameloop to update once in milliseconds. */
     private gameLoopInterval: number = 16.6;
     /** The time for the server to synchronize(send updates) with the client in milliseconds. */
-    private patchRateInterval: number = 22;
+    private patchRateInterval: number = 33.3;
 
     onCreate() {
         console.log(`Created: Game room ${this.roomId}`);

--- a/server/src/rooms/game_room/schemas/ReconciliationInfo.ts
+++ b/server/src/rooms/game_room/schemas/ReconciliationInfo.ts
@@ -1,0 +1,16 @@
+import { Schema, type } from '@colyseus/schema';
+
+export default class ReconciliationInfo extends Schema {
+    @type("string") clientId: string;
+    @type("number") adjustmentAmount: number; // number of ticks the client should adjust.
+    @type("number") adjustmentId: number; // current adjustment id.
+    @type("number") adjectmentConfirmId: number; // confirmed adjustment id.
+
+    constructor(clientId: string) {
+        super();
+        this.adjustmentAmount = 0;
+        this.adjectmentConfirmId = 0;
+        this.adjustmentId = 0;
+        this.clientId = clientId;
+    }
+}

--- a/server/src/rooms/game_room/schemas/State.ts
+++ b/server/src/rooms/game_room/schemas/State.ts
@@ -1,13 +1,14 @@
-import { Schema, type, MapSchema } from '@colyseus/schema';
-import Player from './gameobjs/Player';
+import { Schema, type, MapSchema, ArraySchema, filterChildren } from '@colyseus/schema';
 import GameObject from './gameobjs/GameObject';
 import Tilemap from './dungeon/tilemap/Tilemap';
 import Dungeon from './dungeon/Dungeon';
+import ReconciliationInfo from './ReconciliationInfo';
 
 export default class State extends Schema {
     @type({ map: GameObject })
     gameObjects = new MapSchema<GameObject>();  
     
+    //Deprecated
     @type(Tilemap)
     tilemap:Tilemap|null = null;
 
@@ -18,4 +19,10 @@ export default class State extends Schema {
 
     @type("number") 
     serverTickCount = 0;
+
+    @filterChildren((client, key, value: ReconciliationInfo, root) => {
+        return client.sessionId === value.clientId;
+    })
+    @type([ReconciliationInfo]) 
+    reconciliationInfos = new ArraySchema<ReconciliationInfo>();
 }

--- a/server/src/rooms/game_room/schemas/gameobjs/GameObject.ts
+++ b/server/src/rooms/game_room/schemas/gameobjs/GameObject.ts
@@ -2,11 +2,6 @@ import { Schema, type } from '@colyseus/schema';
 import MathUtil from '../../../../util/MathUtil';
 import { Cloneable } from '../../../../util/PoolUtil';
 
-export class Velocity extends Schema {
-    @type('number') x = 0;
-    @type('number') y = 0;
-}
-
 export default class GameObject extends Schema implements Cloneable {
     @type('string') private id: string;
     @type('string') ownerId;
@@ -16,14 +11,12 @@ export default class GameObject extends Schema implements Cloneable {
     private body: Matter.Body | null = null;
     @type('number') x;
     @type('number') y;
-    @type(Velocity) velocity;
 
     constructor(x: number, y: number, ownerId?: string) {
         super();
         this.id = MathUtil.uid()
         this.x = x;
         this.y = y;
-        this.velocity = new Velocity();
         this.ownerId = ownerId;
         this.type = 'GameObject';
     }

--- a/server/src/rooms/game_room/system/Collisions/MaskManager.ts
+++ b/server/src/rooms/game_room/system/Collisions/MaskManager.ts
@@ -19,7 +19,7 @@ export default class MaskManager {
     }
 
     private initPlayerMasks(){
-        this.setCollideable("PLAYER", "MONSTER")
+        // this.setCollideable("PLAYER", "MONSTER")
         this.setCollideable("PLAYER", "PLAYER_PROJECTILE_FRIENDLY_FIRE")
         this.setCollideable("PLAYER", "MONSTER_PROJECTILE")
         this.setCollideable("PLAYER", "CHEST")

--- a/server/src/rooms/game_room/system/GameManager.ts
+++ b/server/src/rooms/game_room/system/GameManager.ts
@@ -48,8 +48,6 @@ export default class GameManager {
                 if(objState && !obj.isStatic) {
                     objState.x = obj.position.x;
                     objState.y = obj.position.y;
-                    objState.velocity.x = obj.velocity.x;
-                    objState.velocity.y = obj.velocity.y;
                 }
             })
         });

--- a/server/src/rooms/game_room/system/StateManagers/DungeonManager.ts
+++ b/server/src/rooms/game_room/system/StateManagers/DungeonManager.ts
@@ -229,9 +229,9 @@ export default class DungeonManager {
                                 mask: MaskManager.getManager().getMask('OBSTACLE') 
                             };
                             
-                            gameObjects.set(uid, body);
-    
-                            Matter.Composite.add(engine.world, body);
+                            // gameObjects.set(uid, body);
+                            // Matter.Composite.add(engine.world, body);
+                            this.gameManager.addGameObject(uid, tile, body);
                         }
                     }
                 }

--- a/server/src/rooms/game_room/system/StateManagers/PlayerManager.ts
+++ b/server/src/rooms/game_room/system/StateManagers/PlayerManager.ts
@@ -24,6 +24,8 @@ export default class PlayerManager{
             if(gameObject instanceof Player){
                 gameObject.attackCooldown.tick(deltaT)
                 gameObject.specialCooldown.tick(deltaT)
+                let body = gameObject.getBody();
+                if(body) Matter.Body.setPosition(body, {x: 100 + deltaT, y: 100});
             }
         })
     }
@@ -111,7 +113,7 @@ export default class PlayerManager{
         WeaponManager.setWeaponUpgradeTree(newPlayer, tree)
 
         let body = Matter.Bodies.rectangle(newPlayer.x, newPlayer.y, 49, 44, {
-            isStatic: false,
+            isStatic: true,
             inertia: Infinity,
             inverseInertia: 0,
             restitution: 0,

--- a/server/src/rooms/game_room/system/StateManagers/PlayerManager.ts
+++ b/server/src/rooms/game_room/system/StateManagers/PlayerManager.ts
@@ -24,8 +24,6 @@ export default class PlayerManager{
             if(gameObject instanceof Player){
                 gameObject.attackCooldown.tick(deltaT)
                 gameObject.specialCooldown.tick(deltaT)
-                let body = gameObject.getBody();
-                if(body) Matter.Body.setPosition(body, {x: 100 + deltaT, y: 100});
             }
         })
     }
@@ -113,7 +111,7 @@ export default class PlayerManager{
         WeaponManager.setWeaponUpgradeTree(newPlayer, tree)
 
         let body = Matter.Bodies.rectangle(newPlayer.x, newPlayer.y, 49, 44, {
-            isStatic: true,
+            isStatic: false,
             inertia: Infinity,
             inverseInertia: 0,
             restitution: 0,

--- a/server/src/util/MathUtil.ts
+++ b/server/src/util/MathUtil.ts
@@ -42,7 +42,7 @@ export default class MathUtil {
      * @returns Returns the distance squared of two points.
      */
     public static distanceSquared(x1:number, y1:number, x2:number, y2:number) {
-        return Math.pow(x1 - y1, 2) + Math.pow(x2 - y2, 2);
+        return Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2);
     }
 
     /**


### PR DESCRIPTION
Added ClientSidePrediction to enable smoother gameplay experience. Below are some of the changes:
- Added interpolation to smooth out object movements
- Added 33ms simulated latency to the server to simulate real life latency
- Added fixed ticks of 20ms to both the client and server side. Note: client rendering is still at high fps.
- Added ClientSidePrediction by pre-moving the player before the server sends correct position
- Added Server Sync to synchronize the client's tick count to the server's tick count
- Added ServerReconciliation to fix the player's position on the client if it fails to match up with the server
- Fixed bug where the monster don't aggro onto nearest player